### PR TITLE
Turn text wrap off

### DIFF
--- a/arduino/SolderStation.ino
+++ b/arduino/SolderStation.ino
@@ -78,7 +78,7 @@ void setup(void) {
 	
 	tft.setRotation(0);	// 0 - Portrait, 1 - Lanscape
 	tft.fillScreen(QDTech_BLACK);
-	tft.setTextWrap(true);
+	tft.setTextWrap(false);
 	
 	
 	


### PR DESCRIPTION
Set TextWrap to false to get compatibility with different versions of the display
tft.setTextWrap(false);
